### PR TITLE
fix: first pr comment logic (2nd attempt)

### DIFF
--- a/.github/workflows/pr-auto-comments.yml
+++ b/.github/workflows/pr-auto-comments.yml
@@ -104,17 +104,22 @@ jobs:
 
           # Only check if this is their first PR if needed
           if [[ "${{ steps.event.outputs.type }}" == "opened" ]]; then
-            # Check if this is their first PR to the repo using REST API instead of GraphQL
-            PR_COUNT=$(gh api -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=all&creator=$PR_AUTHOR" | jq length)
+            # Use the GitHub Search API to find PRs by this author to this specific repo
+            SEARCH_QUERY="repo:${{ github.repository }} is:pr author:$PR_AUTHOR"
+            PR_SEARCH=$(gh api -H "Accept: application/vnd.github+json" \
+              "/search/issues?q=$(echo $SEARCH_QUERY | sed 's/ /%20/g')&per_page=100" || echo '{"total_count": 0}')
 
-            echo "Found $PR_COUNT PRs from this contributor"
+            # Get the total count from the search results
+            PR_COUNT=$(echo $PR_SEARCH | jq '.total_count')
+
+            echo "Search query: $SEARCH_QUERY"
+            echo "Found $PR_COUNT PRs from this contributor to this repository"
 
             if [ "$PR_COUNT" -eq 1 ]; then
-              echo "First PR from this contributor"
+              echo "First PR from this contributor to this repository"
               echo "is_first_pr=true" >> $GITHUB_OUTPUT
             else
-              echo "Not the first PR from this contributor"
+              echo "Not the first PR from this contributor to this repository"
               echo "is_first_pr=false" >> $GITHUB_OUTPUT
             fi
           else


### PR DESCRIPTION
1. Replaced the previous REST API endpoint with the GitHub Search API, which provides more accurate results for finding PRs by a specific author in a specific repository
2. Used repo:${{ github.repository }} is:pr author:$PR_AUTHOR as the search query to find all PRs by this author to this specific repository
3. Added proper URL encoding for the search query
4. Extracted the total_count field from the search results to determine how many PRs this user has created
5. Added more detailed logging to help with troubleshooting

The GitHub Search API provides a more reliable way to check if a user has submitted PRs to a repository before. It's less likely to be affected by any backend connections between different GitHub accounts.

If for some reason this still doesn't work properly, then yes, using a completely different email address for testing would be a good approach to ensure the accounts are completely separate in GitHub's system.