### PR TITLE
fix: race condition between first-pr and ready-for-review

### DIFF
--- a/.github/workflows/pr-auto-comments.yml
+++ b/.github/workflows/pr-auto-comments.yml
@@ -162,8 +162,12 @@ jobs:
   # Leave a comment when PR is marked ready for review
   ready-for-review-comment:
     name: Ready for Review Comment
-    needs: check-contributor
-    if: (needs.check-contributor.outputs.event_type == 'ready_for_review' || (needs.check-contributor.outputs.event_type == 'opened' && needs.check-contributor.outputs.type_ready == 'true')) && needs.check-contributor.outputs.is_external == 'true' && inputs.ready_for_review_comment != ''
+    needs: [check-contributor, first-pr-comment]
+    if: |
+      (needs.check-contributor.outputs.event_type == 'ready_for_review' ||
+      (needs.check-contributor.outputs.event_type == 'opened' && needs.check-contributor.outputs.type_ready == 'true')) &&
+      needs.check-contributor.outputs.is_external == 'true' &&
+      inputs.ready_for_review_comment != ''
     runs-on: ubuntu-latest
     steps:
       - name: Leave ready for review comment


### PR DESCRIPTION
# Problem
A race condition exists between the `first-pr-comment` and `ready-for-review-comment` jobs. As a result, the `ready-for-review-comment` sometimes prints before the `first-pr-comment`.

# Desired Behavior
The `first-pr-comment` should always print first.

# Changes

* Add `first-pr-comment` to the `needs` array in the `ready-for-review-comment` job. This ensures that the `ready-for-review-comment` job will only run after the `first-pr-comment` job has completed.
* Refactor the long conditional statement to multi-line for readability